### PR TITLE
Add spell checker support with context menu integration

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "bbzcloud",
-  "version": "2.4.5",
+  "version": "2.4.6",
   "description": "Die Desktop-App für die BBZ Cloud - eine All-in-One-Plattform für Unterricht und Zusammenarbeit",
   "main": "public/electron.js",
   "homepage": "./",
@@ -24,6 +24,8 @@
     "@uiw/react-md-editor": "^4.0.5",
     "crypto-js": "^4.2.0",
     "date-fns": "^4.1.0",
+    "dictionary-de": "^3.0.0",
+    "dictionary-en-gb": "^3.0.0",
     "electron-is-dev": "^2.0.0",
     "electron-store": "^8.2.0",
     "electron-updater": "^6.8.0",
@@ -87,6 +89,16 @@
         "filter": [
           "**/*"
         ]
+      },
+      {
+        "from": "node_modules/dictionary-de",
+        "to": "dictionaries/de",
+        "filter": ["index.aff", "index.dic"]
+      },
+      {
+        "from": "node_modules/dictionary-en-gb",
+        "to": "dictionaries/en-GB",
+        "filter": ["index.aff", "index.dic"]
       }
     ],
     "directories": {

--- a/public/electron.js
+++ b/public/electron.js
@@ -1,4 +1,4 @@
-const { app, BrowserWindow, ipcMain, shell, nativeImage, Menu, Tray, dialog, webContents, powerMonitor, screen, globalShortcut, powerSaveBlocker } = require('electron');
+const { app, BrowserWindow, ipcMain, shell, nativeImage, Menu, Tray, dialog, webContents, powerMonitor, screen, globalShortcut, powerSaveBlocker, session } = require('electron');
 const path = require('path');
 const zlib = require('zlib');
 const util = require('util');
@@ -897,9 +897,10 @@ async function getCredentials(service, account) {
   }
 }
 
-function createContextMenu(webContents, selectedText) {
+function createContextMenu(webContents, selectedText, spellItems = []) {
   return Menu.buildFromTemplate([
-    { 
+    ...spellItems,
+    {
       label: 'Ausschneiden',
       accelerator: 'CmdOrCtrl+X',
       role: 'cut'
@@ -1754,7 +1755,24 @@ app.on('web-contents-created', (event, contents) => {
     if (!hasOwnContextMenu) {
       e.preventDefault();
       const selectedText = params.selectionText || '';
-      const menu = createContextMenu(contents, selectedText);
+
+      const spellItems = [];
+      if (params.misspelledWord) {
+        const suggestions = params.dictionarySuggestions ?? [];
+        suggestions.forEach(s => {
+          spellItems.push({ label: s, click: () => contents.replaceMisspelling(s) });
+        });
+        if (suggestions.length > 0) {
+          spellItems.push({ type: 'separator' });
+        }
+        spellItems.push({
+          label: 'Zum Wörterbuch hinzufügen',
+          click: () => contents.session.addWordToSpellCheckerDictionary(params.misspelledWord),
+        });
+        spellItems.push({ type: 'separator' });
+      }
+
+      const menu = createContextMenu(contents, selectedText, spellItems);
       menu.popup();
     }
   });
@@ -2077,6 +2095,13 @@ app.on('ready', async () => {
       }
     }
     
+    // Configure spell checker: prevent Google CDN downloads, use system/OS dictionaries
+    const ses = session.fromPartition('persist:main');
+    ses.setSpellCheckerDictionaryDownloadURL('https://localhost/disabled');
+    if (process.platform !== 'darwin') {
+      ses.setSpellCheckerLanguages(['de', 'en-GB']);
+    }
+
     await copyAssetsIfNeeded();
     createTray();
     createSplashWindow();


### PR DESCRIPTION
## Summary
This PR adds spell checking functionality to the application with integrated context menu support for spell check suggestions and dictionary management.

## Key Changes
- **Spell checker configuration**: Configure Electron's spell checker to use system/OS dictionaries instead of downloading from Google CDN, with German and English (GB) language support
- **Context menu enhancement**: Extended `createContextMenu()` function to accept and display spell check suggestions as menu items
- **Spell check suggestions**: When a misspelled word is detected, the context menu now displays:
  - Dictionary suggestions as clickable items that replace the misspelled word
  - An option to add the word to the spell checker dictionary
  - Proper separators between spell check items and standard context menu actions
- **Dictionary dependencies**: Added `dictionary-de` and `dictionary-en-gb` npm packages with build configuration to bundle the dictionary files (.aff and .dic) into the application
- **Version bump**: Updated to version 2.4.6

## Implementation Details
- The spell checker is configured on the `persist:main` session partition to prevent CDN downloads and use local dictionaries
- On non-macOS platforms, spell checker languages are explicitly set to German and English (GB)
- Spell check suggestions are prepended to the context menu, maintaining the existing cut/copy/paste functionality
- The `contents.replaceMisspelling()` and `session.addWordToSpellCheckerDictionary()` APIs are used to handle spell check actions

https://claude.ai/code/session_01XzcHV37wFEnnCrPL11Fbg8