### PR TITLE
Remove context menu todo addition feature

### DIFF
--- a/public/electron.js
+++ b/public/electron.js
@@ -915,15 +915,6 @@ function createContextMenu(webContents, selectedText, spellItems = []) {
       accelerator: 'CmdOrCtrl+V',
       role: 'paste'
     },
-    { type: 'separator' },
-    {
-      label: 'Als Todo hinzufügen',
-      click: () => {
-        if (selectedText) {
-          mainWindow.webContents.send('add-todo', selectedText);
-        }
-      }
-    }
   ]);
 }
 

--- a/public/preload.js
+++ b/public/preload.js
@@ -133,14 +133,6 @@ contextBridge.exposeInMainWorld('electron', {
     }
   },
   
-  // Context menu todo addition listener
-  onAddTodo: (callback) => {
-    const subscription = (_event, text) => callback(text);
-    ipcRenderer.on('add-todo', subscription);
-    return () => {
-      ipcRenderer.removeListener('add-todo', subscription);
-    };
-  },
   // Secure Documents functionality
   checkSecureStoreAccess: async () => {
     try {

--- a/src/App.js
+++ b/src/App.js
@@ -165,7 +165,6 @@ function App() {
   const [currentUrl, setCurrentUrl] = useState('');
   const [hasUpdate, setHasUpdate] = useState(false);
   const [reminderCount, setReminderCount] = useState(0);
-  const [contextMenuText, setContextMenuText] = useState('');
   const [isDebugMode, setIsDebugMode] = useState(false);
 
   // Refs for WebView management
@@ -531,35 +530,6 @@ function App() {
   // EVENT LISTENERS AND SIDE EFFECTS
   // ============================================================================
   
-  /**
-   * Handle todo additions from context menu
-   * This allows users to right-click on text and add it as a todo
-   */
-  useEffect(() => {
-    if (!window.electron || !window.electron.onAddTodo) {
-      return;
-    }
-    
-    try {
-      const unsubscribe = window.electron.onAddTodo((text) => {
-        setContextMenuText(text);
-        onTodoOpen();
-      });
-      return () => unsubscribe();
-    } catch (error) {
-      console.warn('Error setting up todo context menu listener:', error);
-    }
-  }, [onTodoOpen]);
-
-  /**
-   * Clear context menu text when todo drawer closes
-   */
-  useEffect(() => {
-    if (!isTodoOpen) {
-      setContextMenuText('');
-    }
-  }, [isTodoOpen]);
-
   /**
    * Listen for application update status
    * Shows a red dot on settings button when updates are available
@@ -1206,9 +1176,7 @@ function App() {
             />
           </Flex>
           <Box p={4} overflowY="auto" flex="1">
-            <TodoList 
-              initialText={contextMenuText} 
-              onTextAdded={() => setContextMenuText('')}
+            <TodoList
               isVisible={isTodoOpen}
               onReminderCountChange={setReminderCount}
             />

--- a/src/components/TodoList.js
+++ b/src/components/TodoList.js
@@ -430,7 +430,7 @@ const DeleteFolderModal = ({ isOpen, onClose, onConfirm, folderName, todoCount }
   );
 };
 
-const TodoList = ({ initialText, onTextAdded, isVisible, onReminderCountChange }) => {
+const TodoList = ({ isVisible, onReminderCountChange }) => {
   const [todoState, setTodoState] = useState({
     todos: [],
     folders: ['Default'],
@@ -549,14 +549,6 @@ const TodoList = ({ initialText, onTextAdded, isVisible, onReminderCountChange }
       isClosable: true,
     });
   }, [inputValue, todoState.selectedFolder, toast]);
-
-  // Handle initialText changes
-  useEffect(() => {
-    if (initialText) {
-      handleAddTodo(initialText);
-      onTextAdded();
-    }
-  }, [initialText, handleAddTodo, onTextAdded]);
 
   const handleAddFolder = () => {
     const trimmedName = newFolderName.trim();


### PR DESCRIPTION
## Summary
This PR removes the context menu "Add as Todo" feature that allowed users to right-click on selected text and quickly add it as a todo item. The feature has been completely removed from the application across all relevant layers.

## Key Changes
- **App.js**: Removed `contextMenuText` state and related useEffect hooks that handled context menu todo additions
- **App.js**: Removed `initialText` and `onTextAdded` props from TodoList component
- **TodoList.js**: Removed `initialText` and `onTextAdded` props and the useEffect that processed initial text
- **electron.js**: Removed the "Als Todo hinzufügen" (Add as Todo) context menu item and its click handler
- **preload.js**: Removed the `onAddTodo` IPC listener that bridged the context menu action to the React application

## Implementation Details
The removal is clean and complete, eliminating:
- The IPC communication channel (`add-todo`) between the Electron main process and renderer
- All state management related to context menu text handling
- The context menu UI option in the right-click menu
- The integration point in the TodoList component that consumed this feature

This simplifies the codebase by removing an unused feature path without affecting other todo management functionality.

https://claude.ai/code/session_019jym8XWNTdVuzjfRz2FGsk