### PR TITLE
fix: BBZ Chat reload auto-login + reload-all for WCV apps

### DIFF
--- a/public/electron.js
+++ b/public/electron.js
@@ -2272,6 +2272,10 @@ ipcMain.handle('view:reload', (_e, { appId, ignoreCache }) => {
   viewManager.reload(appId, ignoreCache);
 });
 
+ipcMain.handle('view:reloadAll', (_e, { ignoreCache } = {}) => {
+  viewManager.reloadAll(ignoreCache);
+});
+
 ipcMain.handle('view:goBack', (_e, { appId }) => {
   viewManager.goBack(appId);
 });

--- a/public/preload.js
+++ b/public/preload.js
@@ -328,6 +328,7 @@ contextBridge.exposeInMainWorld('electron', {
     destroy: (appId) => ipcRenderer.invoke('view:destroy', { appId }),
     navigate: (appId, url) => ipcRenderer.invoke('view:navigate', { appId, url }),
     reload: (appId, ignoreCache) => ipcRenderer.invoke('view:reload', { appId, ignoreCache }),
+    reloadAll: (ignoreCache) => ipcRenderer.invoke('view:reloadAll', { ignoreCache }),
     goBack: (appId) => ipcRenderer.invoke('view:goBack', { appId }),
     goForward: (appId) => ipcRenderer.invoke('view:goForward', { appId }),
     executeJavaScript: (appId, code, userGesture) =>

--- a/public/services/ViewManager.js
+++ b/public/services/ViewManager.js
@@ -295,6 +295,13 @@ class ViewManager {
     else entry.view.webContents.reload();
   }
 
+  reloadAll(ignoreCache = false) {
+    for (const entry of this.views.values()) {
+      if (ignoreCache) entry.view.webContents.reloadIgnoringCache();
+      else entry.view.webContents.reload();
+    }
+  }
+
   goBack(appId) {
     const entry = this.views.get(appId);
     if (entry && entry.view.webContents.canGoBack()) entry.view.webContents.goBack();

--- a/src/App.js
+++ b/src/App.js
@@ -932,11 +932,13 @@ function App() {
                 webViewRef.current.reload();
               }
               break;
-            case 'reload-all':
+            case 'reload-all': {
+              if (window.electron?.view?.reloadAll) window.electron.view.reloadAll();
               const webviews = document.querySelectorAll('webview');
               webviews.forEach(webview => webview.reload());
               announceToScreenReader('Alle Webviews werden neu geladen');
               break;
+            }
             case 'toggle-fullscreen':
               if (window.electron && window.electron.toggleFullscreen) {
                 window.electron.toggleFullscreen();
@@ -1086,6 +1088,7 @@ function App() {
         if (webViewRef.current) webViewRef.current.reload();
         break;
       case 'reload-all': {
+        if (window.electron?.view?.reloadAll) window.electron.view.reloadAll();
         const webviews = document.querySelectorAll('webview');
         webviews.forEach(webview => webview.reload());
         announceToScreenReader('Alle Webviews werden neu geladen');

--- a/src/components/WebViewContainer.js
+++ b/src/components/WebViewContainer.js
@@ -439,12 +439,24 @@ const WebViewContainer = forwardRef(({ activeWebView, onNavigate, standardApps }
             try {
               const currentUrl = wcvUrlsRef.current[appId] || '';
               const isBbzChatPage = currentUrl.includes('chat.bbz-rd-eck.com');
-              const needsLogin = await window.electron.view.executeJavaScript(appId, `(function() {
+              const needsLogin = await window.electron.view.executeJavaScript(appId, `(async function() {
                 const isBbzChat = window.location.href.includes('chat.bbz-rd-eck.com');
                 if (isBbzChat) {
                   const loginForm = document.querySelector('input[type="email"]');
+                  if (!loginForm) return false;
                   const token = localStorage.getItem('schulchat_token');
-                  return !!loginForm && !token;
+                  if (!token) return true;
+                  // Validate token; remove if expired so re-login proceeds
+                  try {
+                    const r = await fetch('/api/me', { headers: { 'Authorization': 'Bearer ' + token } });
+                    if (!r.ok) {
+                      localStorage.removeItem('schulchat_token');
+                      return true;
+                    }
+                    return false;
+                  } catch (_) {
+                    return false; // network error — assume valid
+                  }
                 }
                 const emailInput = document.querySelector('input#username[type="text"]');
                 const passwordInputs = document.querySelectorAll('input[type="password"]');
@@ -459,6 +471,7 @@ const WebViewContainer = forwardRef(({ activeWebView, onNavigate, standardApps }
                 setBbzChatLoginActive(false);
               }
               if (needsLogin) {
+                credsAreSet.current[appId] = false;
                 injectCredentials(getWcvProxy(appId), appId);
               }
             } catch (_) {}
@@ -917,12 +930,25 @@ const WebViewContainer = forwardRef(({ activeWebView, onNavigate, standardApps }
               const loginResult = await webview.executeJavaScript(`
                 (async function() {
                   try {
-                    // Check if token exists in localStorage
+                    // Check if token exists in localStorage and validate it
                     const existingToken = localStorage.getItem('schulchat_token');
                     if (existingToken) {
-                      // Trust the token — if invalid, the app will handle auth on next navigation
-                      console.log('[BBZ Chat] Token found, assuming valid');
-                      return 'ALREADY_LOGGED_IN';
+                      try {
+                        const me = await fetch('/api/me', {
+                          headers: { 'Authorization': 'Bearer ' + existingToken }
+                        });
+                        if (me.ok) {
+                          console.log('[BBZ Chat] Token validated via /api/me');
+                          return 'ALREADY_LOGGED_IN';
+                        }
+                        // Token expired/invalid — remove and fall through to fresh login
+                        console.log('[BBZ Chat] Existing token invalid, removing and re-logging in');
+                        localStorage.removeItem('schulchat_token');
+                      } catch (e) {
+                        // Network error — trust the token to avoid logging the user out unnecessarily
+                        console.log('[BBZ Chat] Token validation network error, trusting token');
+                        return 'ALREADY_LOGGED_IN';
+                      }
                     }
 
                     console.log('[BBZ Chat] No token, calling /api/login...');


### PR DESCRIPTION
Two regressions surfaced after the WCV migration:

1. Reloading BBZ Chat did not re-authenticate when the schulchat_token
   in localStorage was expired:
   - injectCredentials trusted ANY existing token without validation
   - The 5s periodic check required token=null to trigger re-injection,
     so an expired-but-present token blocked the retry path.
   Fix: validate the token via /api/me. If it 401s, remove it from
   localStorage and proceed with a fresh /api/login (or surface the
   missing-token state to the periodic check). Network errors keep
   trusting the token to avoid logging users out unnecessarily. The
   periodic check now also resets credsAreSet before re-injecting.


2. The "Alle Seiten neu laden" command (Strg+Shift+R / command palette)
   only iterated document.querySelectorAll('webview'), which now finds
   nothing for standard apps (they're WebContentsView). Add
   ViewManager.reloadAll() + view:reloadAll IPC and call it from both
   reload-all handlers (alongside the existing webview reload that still
   covers dropdown/custom apps).

https://claude.ai/code/session_018xiyYTS5a7ftAivToVqp1p