### PR TITLE
Simplify Nextcloud ADFS login and exclude from login attempt limits

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "bbzcloud",
-  "version": "2.4.8",
+  "version": "2.4.9",
   "description": "Die Desktop-App für die BBZ Cloud - eine All-in-One-Plattform für Unterricht und Zusammenarbeit",
   "main": "public/electron.js",
   "homepage": "./",

--- a/src/components/WebViewContainer.js
+++ b/src/components/WebViewContainer.js
@@ -613,7 +613,7 @@ const WebViewContainer = forwardRef(({ activeWebView, onNavigate, standardApps }
       // Check login attempt limit (except for Outlook, WebUntis, and schulcloud)
       // schulcloud has a multi-step login process (email -> password -> encryption)
       // and the periodic check may trigger multiple times during this process
-      if (id !== 'outlook' && id !== 'webuntis' && id !== 'schulcloud') {
+      if (id !== 'outlook' && id !== 'webuntis' && id !== 'schulcloud' && id !== 'nextcloud') {
         if (!loginAttempts.current[id]) {
           loginAttempts.current[id] = 0;
         }
@@ -1785,38 +1785,9 @@ const WebViewContainer = forwardRef(({ activeWebView, onNavigate, standardApps }
                                        Array.from(document.querySelectorAll('a')).find(a => a.textContent.trim() === 'BBZ ADFS');
                     
                     if (adfsButton) {
-                      console.log('[Nextcloud] Found ADFS button');
-                      console.log('[Nextcloud] Button href (raw):', adfsButton.getAttribute('href'));
-                      console.log('[Nextcloud] Button href (resolved):', adfsButton.href);
-                      
-                      // Method 1: Try creating a proper URL with decoded entities
-                      let targetUrl = adfsButton.href;
-                      
-                      // Decode HTML entities in URL
-                      if (targetUrl) {
-                        const textarea = document.createElement('textarea');
-                        textarea.innerHTML = targetUrl;
-                        targetUrl = textarea.value;
-                        console.log('[Nextcloud] Decoded URL:', targetUrl);
-                      }
-                      
-                      if (targetUrl) {
-                        console.log('[Nextcloud] Navigating to decoded URL');
-                        window.location.href = targetUrl;
-                        return 'NAVIGATED';
-                      }
-                      
-                      // Method 2: Fallback - dispatch proper mouse events
-                      console.log('[Nextcloud] Fallback: dispatching mouse events');
-                      const clickEvent = new MouseEvent('click', {
-                        bubbles: true,
-                        cancelable: true,
-                        view: window,
-                        detail: 1,
-                        button: 0
-                      });
-                      adfsButton.dispatchEvent(clickEvent);
-                      return 'CLICK_DISPATCHED';
+                      console.log('[Nextcloud] Found ADFS button, clicking');
+                      adfsButton.click();
+                      return 'CLICKED';
                     }
                     
                     console.log('[Nextcloud] ADFS button not found!');


### PR DESCRIPTION
## Summary
This PR simplifies the Nextcloud ADFS button click handling and adds Nextcloud to the list of applications excluded from login attempt rate limiting.

## Key Changes
- **Login attempt limit exclusion**: Added `nextcloud` to the condition that excludes certain applications from login attempt rate limiting (alongside `outlook`, `webuntis`, and `schulcloud`). This prevents the periodic login check from triggering multiple times during Nextcloud's multi-step authentication process.
- **Simplified ADFS button click logic**: Refactored the Nextcloud ADFS button interaction from a complex two-method approach (URL decoding + fallback mouse event dispatching) to a simple `click()` call. This reduces code complexity while maintaining the same functionality.

## Implementation Details
- The login attempt limit exclusion follows the same pattern as other applications with multi-step login processes
- The ADFS button click simplification removes unnecessary URL decoding and manual event dispatching, relying on the browser's native click handling instead
- Version bumped from 2.4.8 to 2.4.9

https://claude.ai/code/session_01UEiCNTLutqb8V8wbrvcViX